### PR TITLE
Fix normalizeChildren if is Array

### DIFF
--- a/node/utils/normalizeChildren.ts
+++ b/node/utils/normalizeChildren.ts
@@ -12,7 +12,7 @@ export function normalizeChildren(
             if (typeof child === 'string' || typeof child === 'number') {
                 result.push(new TextNode(`${child}`));
             } else if (Array.isArray(child)) {
-                normalizeChildren(child).forEach(result.push);
+                normalizeChildren(child).forEach((normalized) => result.push(normalized));
             } else if (
                 child.type === NODE_TYPE.ELEMENT ||
                 child.type === NODE_TYPE.TEXT ||


### PR DESCRIPTION
Hello, I'm working on a new structure front-end for the project, and we noticed the instability in the Normalization file when using a map in my component, as well as the repair and I hope you will accept my pull request.

Example to simulate an error:

```
const techs = ["NodeJS", "React Native", "Next"];

  return (
    <ul>
      {techs.map((tech: any) => <li>{tech}</li>)}
    </ul>
  );
```