### PR TITLE
Fix rendering of empty (void) html elements

### DIFF
--- a/examples/01.tsx
+++ b/examples/01.tsx
@@ -47,4 +47,16 @@ if (import.meta.main) {
             '<div class="deno"><h1>title</h1><p valid checked select>land</p><br /><hr /><p>value: hello</p><p>num: 23</p></div>',
         );
     });
+
+    Deno.test('render empty', async ()=>{
+        assertEquals(
+            await (<div/>).render(),
+            `<div></div>`
+        )
+
+        assertEquals(
+            await (<img/>).render(),
+            `<img />`
+        )
+    })
 }

--- a/node/ElementNode.ts
+++ b/node/ElementNode.ts
@@ -7,6 +7,26 @@ const ELEMENT_PROP = {
     INNER_HTML: 'innerHTML',
 };
 
+// List taken from http://w3c.github.io/html-reference/syntax.html
+const VOID_ELEMENTS = new Set<string>([
+    'area',
+    'base',
+    'br',
+    'col',
+    'command',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'keygen',
+    'link',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
+]);
+
 export class ElementNode extends Node {
     type = NODE_TYPE.ELEMENT;
 
@@ -26,8 +46,10 @@ export class ElementNode extends Node {
                 ? this.props[ELEMENT_PROP.INNER_HTML]
                 : (await this.renderChildren()).join('');
 
-        return renderedChildren
-            ? `<${this.name}${renderedProps}>${renderedChildren}</${this.name}>`
+        
+        
+        return (renderedChildren || !VOID_ELEMENTS.has(this.name))
+            ? `<${this.name}${renderedProps}>${renderedChildren || ""}</${this.name}>`
             : `<${this.name}${renderedProps} />`;
     }
 


### PR DESCRIPTION
See #5 

Fixing bug with rendering of some empty html elements. 

Making rendering of empty html elements like div standard conform. The self closing (void element) syntax is only allowed on a small subset of html elements. 

The list of elements, where this is allowed can be seen here <http://w3c.github.io/html-reference/syntax.html#syntax-elements> 

This PR aims to provide a standard compliant fix that uses the void element syntax whenever allowed by the spec.
